### PR TITLE
[ADD] support for enter in <pre>

### DIFF
--- a/commands/enter.js
+++ b/commands/enter.js
@@ -97,3 +97,17 @@ HTMLLIElement.prototype.oEnter = function (offset, firstSplit = true) {
     }
     this.oShiftTab();
 };
+/**
+ * Specific behavior for pre: insert newline (\n) in text or insert p at end.
+ */
+HTMLPreElement.prototype.oEnter = function (offset, firstSplit = true) {
+    if (offset < this.childNodes.length) {
+        const newline = document.createTextNode('\n');
+        this.insertBefore(newline, this.childNodes[offset]);
+    } else {
+        let node = document.createElement('p');
+        this.parentNode.insertBefore(node, this.nextSibling);
+        fillEmpty(node);
+        setCursorStart(node);
+    }
+};

--- a/tests/editor.test.js
+++ b/tests/editor.test.js
@@ -1446,6 +1446,22 @@ describe('Editor', () => {
                     });
                 });
             });
+            describe.only('Pre', () => {
+                it('should insert a line break within the pre', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<pre>ab[]cd</pre>',
+                        stepFunction: insertParagraphBreak,
+                        contentAfter: '<pre>ab\n[]cd</pre>',
+                    });
+                });
+                it('should insert a new paragraph after the pre', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<pre>abc[]</pre>',
+                        stepFunction: insertParagraphBreak,
+                        contentAfter: '<pre>abc</pre><p>[]<br></p>',
+                    });
+                });
+            });
             describe('Consecutive', () => {
                 it('should duplicate an empty paragraph twice', async () => {
                     await testEditor(BasicEditor, {


### PR DESCRIPTION
Note: I notice that it breaks when doing enter then backspace at the end of the <pre>. That is due to a pre-existing bug that puts a <br> at the end of the <pre> when merging an element into it. This should be fixed separately as its scope is definitely larger than just <pre> nodes.