### PR TITLE
[FIX] prevent infinite loop in deleteRange

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -623,10 +623,11 @@ export class OdooEditor {
                 pos2[0].oDeleteBackward(pos2[1]);
                 gen = undefined;
             }, histPos);
-            if (err === UNREMOVABLE_ROLLBACK_CODE || err === UNBREAKABLE_ROLLBACK_CODE) {
+            if (err === UNREMOVABLE_ROLLBACK_CODE || err === UNBREAKABLE_ROLLBACK_CODE || err === 'rollback') {
                 gen = gen || leftDeepOnlyPath(...pos2);
                 pos2 = rightPos(gen.next().value);
             } else {
+                this._recordHistoryCursor();
                 sel = document.defaultView.getSelection();
                 pos2 = isSelForward
                     ? [sel.anchorNode, sel.anchorOffset]
@@ -802,7 +803,6 @@ export class OdooEditor {
      * @returns {?}
      */
     _protect(callback, rollbackCounter) {
-        let error;
         try {
             let result = callback.call(this);
             this.observerFlush();
@@ -810,13 +810,12 @@ export class OdooEditor {
                 return result;
             }
         } catch (err) {
-            error = err;
             if (err !== UNBREAKABLE_ROLLBACK_CODE && err !== UNREMOVABLE_ROLLBACK_CODE) {
                 throw err;
             }
         }
         this.historyRollback(rollbackCounter);
-        return error;
+        return 'rollback';
     }
 
     // HISTORY

--- a/src/tests/editor.test.js
+++ b/src/tests/editor.test.js
@@ -1619,6 +1619,23 @@ describe('Editor', () => {
                     contentAfter: '<p>abc[]ef</p>',
                 });
             });
+            it('should delete last character of paragraph, ignoring the selected paragraph break leading to an unbreakable', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab[c</p><p t="unbreak">]def</p>',
+                    // This type of selection (typically done with a triple
+                    // click) is "corrected" before remove so triple clicking
+                    // doesn't remove a paragraph break.
+                    stepFunction: deleteBackward,
+                    contentAfter: '<p>ab[]</p><p t="unbreak">def</p>',
+                });
+            });
+            it('should delete first character of unbreakable, ignoring selected paragraph break', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>abc[</p><p t="unbreak">d]ef</p>',
+                    stepFunction: deleteBackward,
+                    contentAfter: '<p>abc[]</p><p t="unbreak">ef</p>',
+                });
+            });
             it('should remove a fully selected table', async () => {
                 await testEditor(BasicEditor, {
                     contentBefore: unformat(


### PR DESCRIPTION
This fixes a bug that triggered an infinite loop when deleting range in `<p>abc[</p><p t="unbreak">d]ef</p>`.

The selection was not properly rolled back when rolling back in the middle of a range deletion process. This was solved by recording the cursor position in the `deleteRange` loop when no error or rollback occurred.

Before this fix, this was the dom at the beginning of each step of the `deleteRange` loop:
```html
1. <p>abc[<img></p><p t="unbreak">d]ef</p>
2. <p>abc<img></p><p t="unbreak">[]ef</p>
<!-- ROLLBACK 1 -->
3. <p>abc[<img></p><p t="unbreak">e]f</p>
4. <p>ab[]<img></p><p t="unbreak">ef</p>
5. <p>[]<img></p><p t="unbreak">ef</p>
<!-- ROLLBACK -->
6. []<p><img></p><p t="unbreak">ef</p>
<!-- CONTINUE OUT OF CONTENTEDITABLE -->
```
After rollback 1, we had dom 2 with the selection of dom 1.
This being corrected, we predictably entered an infinite loop over dom 2 and rollback 1.
This was solved by ensuring that `pos2` is moved after a rollback.
