### PR TITLE
[FIX] Utils: better visible string detection 

### DIFF
--- a/src/tests/editor.test.js
+++ b/src/tests/editor.test.js
@@ -12,6 +12,11 @@ import {
     unformat,
 } from './utils.js';
 
+async function twoDeleteForward(editor) {
+    await deleteForward(editor);
+    await deleteForward(editor);
+}
+
 describe('Editor', () => {
     describe('deleteForward', () => {
         describe('Selection collapsed', () => {
@@ -87,16 +92,96 @@ describe('Editor', () => {
                             '<table><tbody><tr><td>[]<br></td><td>abc</td></tr></tbody></table>',
                     });
                 });
-                it('should merge the following inline text node', async () => {
-                    await testEditor(BasicEditor, {
-                        contentBefore: '<p>abc</p>[]def',
-                        stepFunction: deleteBackward,
-                        contentAfter: '<p>abc[]def</p>',
+            });
+            describe('white spaces', () => {
+                describe('no intefering spaces', () => {
+                    it('should delete a br line break', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<p>abc[]<br>def</p>',
+                            stepFunction: deleteForward,
+                            contentAfter: '<p>abc[]def</p>',
+                        });
                     });
-                    await testEditor(BasicEditor, {
-                        contentBefore: '<p>abc</p>[]def<p>ghi</p>',
-                        stepFunction: deleteBackward,
-                        contentAfter: '<p>abc[]def</p><p>ghi</p>',
+                    it('should delete a line break and merge the <p>', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<p>abc[]</p><p>def</p>',
+                            stepFunction: deleteForward,
+                            contentAfter: '<p>abc[]def</p>',
+                        });
+                    });
+                });
+                describe('intefering spaces', () => {
+                    it('should delete a br line break', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<p>abc[]<br> def</p>',
+                            stepFunction: deleteForward,
+                            contentAfter: '<p>abc[]def</p>',
+                        });
+                    });
+                    it('should merge the two <p>', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<p>abc[]</p> <p>def</p>',
+                            stepFunction: deleteForward,
+                            contentAfter: '<p>abc[]def</p>',
+                        });
+                    });
+                    it('should delete the space if the second <p> is display inline', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<div>abc[] <p style="display: inline">def</p></div>',
+                            stepFunction: deleteForward,
+                            contentAfter: '<div>abc[]<p style="display: inline">def</p></div>',
+                        });
+                    });
+                    it('should delete the space between the two <span>', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<div><span>abc[]</span> <span>def</span></div>',
+                            stepFunction: deleteForward,
+                            contentAfter: '<div><span>abc[]def</span></div>',
+                        });
+                    });
+                    it('should delete the space before a <span>', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<div>abc[] <span>def</span></div>',
+                            stepFunction: deleteForward,
+                            contentAfter: '<div>abc[]<span>def</span></div>',
+                        });
+                    });
+                });
+                describe('intefering spaces, multiple deleteForward', () => {
+                    it('should delete a br line break', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<p>abc[]x<br> def</p>',
+                            stepFunction: twoDeleteForward,
+                            contentAfter: '<p>abc[]def</p>',
+                        });
+                    });
+                    it('should merge the two <p>', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<p>abc[]x</p> <p>def</p>',
+                            stepFunction: twoDeleteForward,
+                            contentAfter: '<p>abc[]def</p>',
+                        });
+                    });
+                    it('should delete the space if the second <p> is display inline', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<div>abc[]x <p style="display: inline">def</p></div>',
+                            stepFunction: twoDeleteForward,
+                            contentAfter: '<div>abc[]<p style="display: inline">def</p></div>',
+                        });
+                    });
+                    it('should delete the space between the two <span>', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<div><span>abc[]x</span> <span>def</span></div>',
+                            stepFunction: twoDeleteForward,
+                            contentAfter: '<div><span>abc[]def</span></div>',
+                        });
+                    });
+                    it('should delete the space before a <span>', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<div>abc[]x <span>def</span></div>',
+                            stepFunction: twoDeleteForward,
+                            contentAfter: '<div>abc[]<span>def</span></div>',
+                        });
                     });
                 });
             });
@@ -528,7 +613,7 @@ describe('Editor', () => {
                                 <tr><td>cd</td><td>ef</td></tr>
                                 <tr><td>gh</td><td>ij</td></tr>
                             </tbody></table>
-                            <p>kl</p>`
+                            <p>kl</p>`,
                         ),
                         stepFunction: deleteForward,
                         contentAfter: unformat(
@@ -537,7 +622,7 @@ describe('Editor', () => {
                                 <tr><td>cd</td><td>ef</td></tr>
                                 <tr><td>gh</td><td>ij</td></tr>
                             </tbody></table>
-                            <p>kl</p>`
+                            <p>kl</p>`,
                         ),
                     });
                 });
@@ -549,7 +634,7 @@ describe('Editor', () => {
                                 <tr><td>cd</td><td>ef</td></tr>
                                 <tr><td>gh</td><td>ij[]</td></tr>
                             </tbody></table>
-                            <p>kl</p>`
+                            <p>kl</p>`,
                         ),
                         stepFunction: deleteForward,
                         contentAfter: unformat(
@@ -558,7 +643,7 @@ describe('Editor', () => {
                                 <tr><td>cd</td><td>ef</td></tr>
                                 <tr><td>gh</td><td>ij[]</td></tr>
                             </tbody></table>
-                            <p>kl</p>`
+                            <p>kl</p>`,
                         ),
                     });
                 });
@@ -785,6 +870,18 @@ describe('Editor', () => {
                         stepFunction: deleteBackward,
                         contentAfter:
                             '<table><tbody><tr><td>[]<br></td><td>abc</td></tr></tbody></table>',
+                    });
+                });
+                it('should merge the following inline text node', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>abc</p>[]def',
+                        stepFunction: deleteBackward,
+                        contentAfter: '<p>abc[]def</p>',
+                    });
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>abc</p>[]def<p>ghi</p>',
+                        stepFunction: deleteBackward,
+                        contentAfter: '<p>abc[]def</p><p>ghi</p>',
                     });
                 });
             });
@@ -1435,7 +1532,7 @@ describe('Editor', () => {
                                 <tr><td>cd</td><td>ef</td></tr>
                                 <tr><td>gh</td><td>ij</td></tr>
                             </tbody></table>
-                            <p>[]kl</p>`
+                            <p>[]kl</p>`,
                         ),
                         stepFunction: deleteBackward,
                         contentAfter: unformat(
@@ -1444,7 +1541,7 @@ describe('Editor', () => {
                                 <tr><td>cd</td><td>ef</td></tr>
                                 <tr><td>gh</td><td>ij</td></tr>
                             </tbody></table>
-                            <p>[]kl</p>`
+                            <p>[]kl</p>`,
                         ),
                     });
                 });
@@ -1456,7 +1553,7 @@ describe('Editor', () => {
                                 <tr><td>[]cd</td><td>ef</td></tr>
                                 <tr><td>gh</td><td>ij</td></tr>
                             </tbody></table>
-                            <p>kl</p>`
+                            <p>kl</p>`,
                         ),
                         stepFunction: deleteBackward,
                         contentAfter: unformat(
@@ -1465,7 +1562,7 @@ describe('Editor', () => {
                                 <tr><td>[]cd</td><td>ef</td></tr>
                                 <tr><td>gh</td><td>ij</td></tr>
                             </tbody></table>
-                            <p>kl</p>`
+                            <p>kl</p>`,
                         ),
                     });
                 });
@@ -1627,7 +1724,7 @@ describe('Editor', () => {
                             <tr><td>cd</td><td>ef</td></tr>
                             <tr><td>gh</td><td>ij</td></tr>
                         </tbody></table>
-                        <p>k]l</p>`
+                        <p>k]l</p>`,
                     ),
                     stepFunction: deleteBackward,
                     contentAfter: '<p>a[]l</p>',
@@ -1641,7 +1738,7 @@ describe('Editor', () => {
                             <tr><td>cd</td><td>ef</td></tr>
                             <tr><td>g]h</td><td>ij</td></tr>
                         </tbody></table>
-                        <p>kl</p>`
+                        <p>kl</p>`,
                     ),
                     stepFunction: deleteBackward,
                     contentAfter: unformat(
@@ -1650,7 +1747,7 @@ describe('Editor', () => {
                             <tr><td><br></td><td><br></td></tr>
                             <tr><td>h</td><td>ij</td></tr>
                         </tbody></table>
-                        <p>kl</p>`
+                        <p>kl</p>`,
                     ),
                 });
             });

--- a/src/tests/fontAwesome.test.js
+++ b/src/tests/fontAwesome.test.js
@@ -197,6 +197,39 @@ describe('FontAwesome', () => {
                             '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">​</i>[]d</p>',
                     });
                 });
+                it('should not delete a fontawesome after multiple deleteForward', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>ab[]cde<i class="fa fa-pastafarianism"></i>fghij</p>',
+                        stepFunction: async editor => {
+                            await deleteForward(editor);
+                            await deleteForward(editor);
+                            await deleteForward(editor);
+                        },
+                        contentAfter:
+                            '<p>ab[]<i class="fa fa-pastafarianism" contenteditable="false">​</i>fghij</p>',
+                    });
+                });
+                it('should not delete a fontawesome after one deleteForward with spaces', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>ab[] <i class="fa fa-pastafarianism"></i> cd</p>',
+                        stepFunction: async editor => {
+                            await deleteForward(editor);
+                        },
+                        contentAfter:
+                            '<p>ab[]<i class="fa fa-pastafarianism" contenteditable="false">​</i> cd</p>',
+                    });
+                });
+                it('should not delete a fontawesome after multiple deleteForward with spaces', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>a[]b <i class="fa fa-pastafarianism"></i> cd</p>',
+                        stepFunction: async editor => {
+                            await deleteForward(editor);
+                            await deleteForward(editor);
+                        },
+                        contentAfter:
+                            '<p>a[]<i class="fa fa-pastafarianism" contenteditable="false">​</i> cd</p>',
+                    });
+                });
             });
         });
         describe('Selection not collapsed', () => {
@@ -236,6 +269,30 @@ describe('FontAwesome', () => {
                             '<p>a[]<i class="fa fa-pastafarianism" contenteditable="false">​</i>cd</p>',
                     });
                 });
+                it('should not delete a fontawesome after multiple deleteBackward', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>abcde<i class="fa fa-pastafarianism"></i>fgh[]ij</p>',
+                        stepFunction: async editor => {
+                            await deleteBackward(editor);
+                            await deleteBackward(editor);
+                            await deleteBackward(editor);
+                        },
+                        contentAfter:
+                            '<p>abcde<i class="fa fa-pastafarianism" contenteditable="false">​</i>[]ij</p>',
+                    });
+                });
+                it('should not delete a fontawesome after multiple deleteBackward with spaces', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<p>abcde <i class="fa fa-pastafarianism"></i> fg[]hij</p>',
+                        stepFunction: async editor => {
+                            await deleteBackward(editor);
+                            await deleteBackward(editor);
+                            await deleteBackward(editor);
+                        },
+                        contentAfter:
+                            '<p>abcde <i class="fa fa-pastafarianism" contenteditable="false">​</i>[]hij</p>',
+                    });
+                });
             });
         });
         describe('Selection not collapsed', () => {
@@ -254,6 +311,46 @@ describe('FontAwesome', () => {
                         contentAfter: '<p>ab[]cd</p>',
                     });
                 });
+            });
+        });
+    });
+    describe('FontAwesome insertion', () => {
+        it('should insert a fontAwesome', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>ab[]cd</p>',
+                stepFunction: async editor => {
+                    editor._insertFontAwesome('fa fa-star');
+                },
+                contentAfter: '<p>ab<i class="fa fa-star" contenteditable="false">​</i>[]cd</p>',
+            });
+        });
+        it('should insert a fontAwesome after', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>ab<i class="fa fa-pastafarianism"></i>c[]d</p>',
+                stepFunction: async editor => {
+                    editor._insertFontAwesome('fa fa-star');
+                },
+                contentAfter:
+                    '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">​</i>c<i class="fa fa-star" contenteditable="false">​</i>[]d</p>',
+            });
+        });
+        it('should insert a fontAwesome before', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>ab[]<i class="fa fa-pastafarianism"></i>cd</p>',
+                stepFunction: async editor => {
+                    editor._insertFontAwesome('fa fa-star');
+                },
+                contentAfter:
+                    '<p>ab<i class="fa fa-star" contenteditable="false">​</i>[]<i class="fa fa-pastafarianism" contenteditable="false">​</i>cd</p>',
+            });
+        });
+        it.skip('should insert a fontAwesome and replace the icon', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>ab[<i class="fa fa-pastafarianism"></i>]cd</p>',
+                stepFunction: async editor => {
+                    editor._insertFontAwesome('fa fa-star');
+                },
+                contentAfter: '<p>abs<i class="fa fa-star" contenteditable="false">​</i>[]cd</p>',
             });
         });
     });
@@ -276,6 +373,15 @@ describe('FontAwesome', () => {
                 },
                 contentAfter:
                     '<p>ab<i class="fa fa-pastafarianism" contenteditable="false">​</i>s[]cd</p>',
+            });
+        });
+        it.skip('should insert a character and replace the icon', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>ab[<i class="fa fa-pastafarianism"></i>]cd</p>',
+                stepFunction: async editor => {
+                    await insertText(editor, 's');
+                },
+                contentAfter: '<p>abs[]cd</p>',
             });
         });
     });

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -574,8 +574,7 @@ export function isUnremovable(node) {
         return true;
     }
     const isEditableRoot = node.isContentEditable && !node.parentElement.isContentEditable;
-    return isEditableRoot ||
-        node.classList && node.classList.contains('oe_unremovable');
+    return isEditableRoot || (node.classList && node.classList.contains('oe_unremovable'));
 }
 
 export function containsUnbreakable(node) {
@@ -633,13 +632,19 @@ export function isInPre(node) {
     );
 }
 /**
- * Returns whether the given string (or given text node value) has
- * non-whitespace characters in it.
+ * Returns whether the given string (or given text node value)
+ * has at least one visible character or one non colapsed whitespace characters in it.
  */
 const nonWhitespacesRegex = /[\S\u00A0]/;
 export function isVisibleStr(value) {
     const str = typeof value === 'string' ? value : value.nodeValue;
-    return nonWhitespacesRegex.test(str);
+    return (
+        nonWhitespacesRegex.test(str) ||
+        (str.length > 0 &&
+            value.nextSibling &&
+            value.nextSibling.nodeType !== Node.TEXT_NODE &&
+            window.getComputedStyle(value.nextSibling).display !== 'block')
+    );
 }
 /**
  * @param {Node} node


### PR DESCRIPTION
Take some spaces into account and ignore others in the method `isVisibleStr()`

It's necessary to be able to properly delete a space that has been detached from a preceding text node in a previous operation.

   ex : `<p>ab[]c <span>de</span></p>`
   first delete forward will split the text node in [ab] and[ ]
   the second delete forward must not ignore the white space here.