### PR TITLE
[FIX] properly redo

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -447,14 +447,17 @@ export class OdooEditor {
     }
 
     historyRedo() {
-        this.historyStep();
         let pos = this.history.length - 2;
         if (this.undos.has(pos)) {
             this.historyApply(this.dom, this.history[this.undos.get(pos)].dom);
             let step = this.history[this.undos.get(pos) + 1];
             this.historySetCursor(step);
-            this.undos.set(pos + 1, this.undos.get(pos) + 1);
+            // Remove the history step that was reverted and its matching undo.
+            // Unlike undo, redo consumes history steps.
+            this.history.splice(pos, 1);
+            this.history.splice(this.undos.get(pos), 1);
             this.undos.delete(pos);
+            this.historyStep();
         }
     }
 

--- a/src/tests/editor.test.js
+++ b/src/tests/editor.test.js
@@ -6,9 +6,11 @@ import {
     deleteForward,
     insertLineBreak,
     insertParagraphBreak,
+    redo,
     testEditor,
     testVdom,
     toggleBold,
+    undo,
     unformat,
 } from './utils.js';
 
@@ -2763,6 +2765,69 @@ describe('Editor', () => {
             contentBefore: '<p><b>a[b]c</b></p>',
             stepFunction: toggleBold,
             contentAfter: '<p><b>a</b>b<b>c</b></p>',
+        });
+    });
+
+    describe('history', () => {
+        describe('undo', () => {
+            it('should undo a backspace', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab []cd</p>',
+                    stepFunction: async editor => {
+                        await deleteBackward(editor); // <p>ab[]cd</p>
+                        undo(editor); // <p>ab []cd</p>
+                    },
+                    contentAfter: '<p>ab []cd</p>',
+                });
+            });
+            it('should undo a backspace, then do nothing on undo', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab []cd</p>',
+                    stepFunction: async editor => {
+                        await deleteBackward(editor); // <p>ab[]cd</p>
+                        undo(editor); // <p>ab []cd</p>
+                        undo(editor); // <p>ab []cd</p> (nothing to undo)
+                    },
+                    contentAfter: '<p>ab []cd</p>',
+                });
+            });
+        });
+        describe('redo', () => {
+            it('should undo, then redo a backspace', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab []cd</p>',
+                    stepFunction: async editor => {
+                        await deleteBackward(editor); // <p>ab[]cd</p>
+                        undo(editor); // <p>ab []cd</p>
+                        redo(editor); // <p>ab[]cd</p>
+                    },
+                    contentAfter: '<p>ab[]cd</p>',
+                });
+            });
+            it('should undo, then redo a backspace, then undo again to get back to the starting point', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab []cd</p>',
+                    stepFunction: async editor => {
+                        await deleteBackward(editor); // <p>ab[]cd</p>
+                        undo(editor); // <p>ab []cd</p>
+                        redo(editor); // <p>ab[]cd</p>
+                        undo(editor); // <p>ab []cd</p>
+                    },
+                    contentAfter: '<p>ab []cd</p>',
+                });
+            });
+            it('should undo, then redo a backspace, then do nothing on redo', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab []cd</p>',
+                    stepFunction: async editor => {
+                        await deleteBackward(editor); // <p>ab[]cd</p>
+                        undo(editor); // <p>ab []cd</p>
+                        redo(editor); // <p>ab[]cd</p>
+                        redo(editor); // <p>ab[]cd</p> (nothing to redo)
+                    },
+                    contentAfter: '<p>ab[]cd</p>',
+                });
+            });
         });
     });
 });

--- a/src/tests/utils.js
+++ b/src/tests/utils.js
@@ -371,6 +371,14 @@ export async function insertText(editor, text) {
     sel.collapseToEnd();
 }
 
+export function undo(editor) {
+    editor.historyUndo();
+}
+
+export function redo(editor) {
+    editor.historyRedo();
+}
+
 export function simulateToolbarClick(editor, buttonId) {
     const button = document.createElement('div');
     button.classList.add('btn');


### PR DESCRIPTION
- Adding a call to `historyStep` at the end of redo ensures we have no inconsistency and our last step is a placeholder.
- Removing the history step that was redone as well as its equivalent undo history step ensures we do not have an infinite redo loop.