### PR TITLE
[FIX] history: bug with redo

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -496,12 +496,14 @@ export class OdooEditor {
 
     historyRedo() {
         let pos = this.history.length - 2;
+        let total = 0;      // check if we have not more 2 than 0 until we get to the 1
         while (this.undos.has(pos) && this.undos.get(pos) != 1) {
+            total += this.undos.get(pos)-1;
             pos --;
         }
-        if (this.undos.get(pos) == 1) {
-            this.historyRevert(this.history[pos]);
+        if ((this.undos.get(pos) == 1) && (total<=0)) {
             this.undos.set(pos, 2);
+            this.historyRevert(this.history[pos]);
             this.undos.set(this.history.length - 1, 0);
             this.historySetCursor(this.history[pos]);
             this.historyStep();


### PR DESCRIPTION
fixes the bug with redo, with a simpler implementation of undo/redo:

start text: 'foo'
- ajoute trois lettre (abc)
- undo x2
texte: fooa
- ajoute une lettre différente (d)
texte: fooad
- undo
- redo
texte: fooad
- undo x2
- redo x2
texte: fooabc