### PR TITLE
[FIX] fix oDeleteBackward infinite loop

### DIFF
--- a/src/commands/deleteBackward.js
+++ b/src/commands/deleteBackward.js
@@ -22,6 +22,7 @@ import {
     isFontAwesome,
     isUnbreakable,
     isMediaElement,
+    isVisibleEmpty,
 } from '../utils/utils.js';
 
 Text.prototype.oDeleteBackward = function (offset, alreadyMoved = false) {
@@ -72,7 +73,7 @@ HTMLElement.prototype.oDeleteBackward = function (offset, alreadyMoved = false) 
             leftNode.remove();
             return;
         }
-        if (!isBlock(leftNode)) {
+        if (!isBlock(leftNode) || isVisibleEmpty(leftNode)) {
             /**
              * Backspace just after an inline node, convert to backspace at the
              * end of that inline node.

--- a/src/tests/editor.test.js
+++ b/src/tests/editor.test.js
@@ -651,6 +651,13 @@ describe('Editor', () => {
                         ),
                     });
                 });
+                it('should delete an image that is displayed as a block', async () => {
+                    await testEditor(BasicEditor, {
+                        contentBefore: unformat(`<div>a[b<img style="display: block;"/>c]d</div>`),
+                        stepFunction: editor => editor._applyCommand('oDeleteBackward'),
+                        contentAfter: unformat(`<div>a[]d</div>`),
+                    });
+                });
             });
         });
         describe('Selection not collapsed', () => {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -948,6 +948,9 @@ export function moveNodes(
     startIndex = 0,
     endIndex = sourceEl.childNodes.length,
 ) {
+    if (selfClosingElementTags.includes(destinationEl.nodeName)) {
+        throw new Error(`moveNodes: Invalid destination element ${destinationEl.nodeName}`);
+    }
     // For table elements, there just cannot be a meaningful move, add them
     // after the table.
     if (['TBODY', 'THEAD', 'TFOOT', 'TR', 'TH', 'TD'].includes(destinationEl.tagName)) {


### PR DESCRIPTION
oDeleteBackward would loop infinitely when trying to delete a range containing a img that was displayed as a block.