### PR TITLE
[FIX] make divs unbreakable

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -565,7 +565,7 @@ export function isUnbreakable(node) {
     }
     return (
         isUnremovable(node) || // An unremovable node is always unbreakable.
-        ['THEAD', 'TBODY', 'TFOOT', 'TR', 'TH', 'TD', 'SECTION'].includes(node.tagName) ||
+        ['THEAD', 'TBODY', 'TFOOT', 'TR', 'TH', 'TD', 'SECTION', 'DIV'].includes(node.tagName) ||
         node.hasAttribute('t') ||
         node.classList.contains('oe_unbreakable')
     );


### PR DESCRIPTION
When divs aren't unbreakable, pressing enter can duplicate elements it shouldn't
eg. when the cursor is at the end of a "big box" type of block in website.