### PR TITLE
[FIX] fix unindent li behavior

### DIFF
--- a/src/commands/shiftTab.js
+++ b/src/commands/shiftTab.js
@@ -31,9 +31,10 @@ HTMLLIElement.prototype.oShiftTab = function (offset) {
 
     const restoreCursor = preserveCursor(this.ownerDocument);
     if (li.parentNode.parentNode.tagName === 'LI') {
-        let toremove = !li.previousElementSibling ? li.parentNode.parentNode : null;
-        let ul = li.parentNode;
-        li.parentNode.parentNode.after(li);
+        const ul = li.parentNode;
+        const shouldRemoveParentLi = !li.previousElementSibling && !ul.previousElementSibling;
+        const toremove = shouldRemoveParentLi ? ul.parentNode : null;
+        ul.parentNode.after(li);
         if (toremove) {
             if (toremove.classList.contains('oe-nested')) {
                 // <li>content<ul>...</ul></li>


### PR DESCRIPTION
Unindent in the case of a nested li would only check that it is the only child of its ul, removing the parent li in that case, whithout checking that the ul was also the only child of the parent li.
Long story short, unindenting this:
```html
<ul>
  <li class="oe-nested">
    <ul><li>1</li></ul>
    <ul><li>[2]</li></ul>
  </li>
</ul>
```
would result in this

```html
<ul>
  <li>[2]</li>
</ul>
```
Instead of this
```html
<ul>
  <li class="oe-nested">
    <ul><li>1</li></ul>
  </li>
  <li>[2]</li>
</ul>
```