### PR TITLE
[FIX] break link after enter if cursor at the end of the <a> tag

### DIFF
--- a/src/commands/enter.js
+++ b/src/commands/enter.js
@@ -64,7 +64,11 @@ HTMLElement.prototype.oEnter = function (offset, firstSplit = true) {
         fillEmpty(clearEmpty(this));
         fillEmpty(splitEl);
 
-        setCursorStart(splitEl);
+        const focusToElement =
+            splitEl.nodeType === Node.ELEMENT_NODE && splitEl.tagName === 'A'
+                ? clearEmpty(splitEl)
+                : splitEl;
+        setCursorStart(focusToElement);
     }
     return splitEl;
 };


### PR DESCRIPTION
Bug report : [SBU] Press "Enter" at the end of the link, the first letter of the new line is within the link...: https://drive.google.com/file/d/1RdNS1oPAUq8n-e82KC2VUUSq95JbjaP0/view

