### PR TITLE
[FIX] unlink was broken after be5dd084

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -1055,6 +1055,13 @@ export class OdooEditor extends EventTarget {
 
     _unlink(offset, content) {
         const sel = this.document.defaultView.getSelection();
+        // we need to remove the contentEditable isolation of links
+        // before we apply the unlink, otherwise the command is not performed
+        // because the content editable root is the link
+        const closestEl = closestElement(sel.focusNode);
+        if (closestEl.tagName === 'A' && closestEl.getAttribute('contenteditable') === 'true') {
+            this._activateContenteditable();
+        }
         if (sel.isCollapsed) {
             const cr = preserveCursor(this.document);
             const node = closestElement(sel.focusNode, 'a');


### PR DESCRIPTION
Bug report : 
[SGE-03] Website editor : unlink button doesn't work when focus inside a link
    👁‍ See: https://www.awesomescreenshot.com/video/2964099?key=b2a21716a0c80749a5f288b45d19038c
    ❗️ Steps to Reproduce : 
    1. start website editing
    2. add a snippet text
    3. create a link
    4. click in the newly created link
    5. click the unlink button in the toolbar it doesn't work -> NOK ❌

✅ Expected behavior : 
     unlink buton should always unlink the slected range or the link the cursor is anchor into

ℹ️ Branch: master-odoo-editor-integration-all | Last Commit: odoo:9e0f456b [FIX] create link rather than getting it


