### PR TITLE
[FIX] prevent traceback on delete

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -831,7 +831,12 @@ export class OdooEditor extends EventTarget {
             joinWith.textContent = oldText.replace(/ $/, '\u00A0');
         }
         // Rejoin blocks that extractContents may have split in two.
-        while (doJoin && next && !(next.previousSibling && next.previousSibling === joinWith)) {
+        while (
+            doJoin &&
+            next &&
+            !(next.previousSibling && next.previousSibling === joinWith) &&
+            this.dom.contains(next)
+        ) {
             const restore = preserveCursor(this.document);
             this.observerFlush();
             const res = this._protect(() => {


### PR DESCRIPTION
Prevent this bug in Odoo:
1. Create a mail with template 3
2. Select backwards (with the mouse) from just after the last "Read more" button, until the beginning of "Premium Pass"
3. Press the BACKSPACE key
4. Traceback: "Uncaught TypeError: Cannot read property 'nodeName' of null" at Text.oDeleteBackward > HTMLElement.oDeleteBackward > HTMLElement.oDeleteBackward > moveNodes