### PR TITLE
[ADD] make get adjacent fit current use case

### DIFF
--- a/src/tests/utils.test.js
+++ b/src/tests/utils.test.js
@@ -669,22 +669,23 @@ describe('Utils', () => {
             const result = getAdjacents(ij);
             window.chai.expect(result).to.eql([ij]);
         });
-        it('should find only the adjacent siblings of a deeply nested node that are elements', () => {
-            const [p] = insertTestHtml('<p><b>ab<i>cd<u>ef</u>gh<span>ij</span>kl</i>mn</b>op</p>');
+        it('should find the adjacent siblings of a deeply nested node that are elements', () => {
+            const [p] = insertTestHtml(
+                '<p><b>ab<i>cd<u>ef</u><span>gh</span><span>ij</span>kl</i>mn</b>op</p>',
+            );
             const gh = p.firstChild.childNodes[1].childNodes[2];
             const u = gh.previousSibling;
             const span = gh.nextSibling;
             const result = getAdjacents(gh, node => node.nodeType === Node.ELEMENT_NODE);
-            window.chai.expect(result).to.eql([u, span]);
+            window.chai.expect(result).to.eql([u, gh, span]);
         });
-        it('should find only the adjacent siblings of a deeply nested node that are text nodes', () => {
+        it('should return an empty array if the given node is not satisfying the given predicate', () => {
             const [p] = insertTestHtml(
                 '<p><b>ab<i>cd<u>ef</u><a>gh</a>ij<span>kl</span>mn</i>op</b>qr</p>',
             );
-            const a = p.firstChild.childNodes[1].childNodes[2];
-            const ij = a.nextSibling;
+            const a = p.querySelector('a');
             const result = getAdjacents(a, node => node.nodeType === Node.TEXT_NODE);
-            window.chai.expect(result).to.eql([ij]);
+            window.chai.expect(result).to.eql([]);
         });
     });
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -359,18 +359,16 @@ export function getAdjacentNextSiblings(node, predicate = n => !!n) {
 }
 /**
  * Returns all the adjacent siblings of the given node until the first sibling
- * (in both directions) that does not satisfy the predicate, in index order.
+ * (in both directions) that does not satisfy the predicate, in index order. If
+ * the given node does not satisfy the predicate, an empty array is returned.
  *
  * @param {Node} node
  * @param {Function} [predicate] (node: Node) => boolean
- * @param {boolean} [includeSelf] default true
  */
-export function getAdjacents(node, predicate = n => !!n, includeSelf = true) {
+export function getAdjacents(node, predicate = n => !!n) {
     const previous = getAdjacentPreviousSiblings(node, predicate);
     const next = getAdjacentNextSiblings(node, predicate);
-    return includeSelf && predicate(node)
-        ? [...previous.reverse(), node, ...next]
-        : [...previous.reverse(), ...next];
+    return predicate(node) ? [...previous.reverse(), node, ...next] : [];
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
getAdjacent was written with the intent of easyly finding groups of nodes.
For example, a group of nodes that should be wrapped into a <p> but are direct children of the root editable: you would need to grab all the inline and text node that are siblings, but stop collecting them once you encounter a block.