### PR TITLE
[FIX] table : fix traceback on table insertion

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -1025,11 +1025,11 @@ export class OdooEditor extends EventTarget {
     }
 
     _insertHTML(data) {
-        this._insert(data, false);
+        return this._insert(data, false);
     }
 
     _insertText(data) {
-        this._insert(data);
+        return this._insert(data);
     }
 
     /**


### PR DESCRIPTION
`_insertHTML()` was not returning the value from `_insert()` which is necessary for the table insertion logic to function properly.