### PR TITLE
[FIX] prevent traceback on isBlock in iframe

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -792,7 +792,7 @@ const computedStyles = new WeakMap();
  * @param node
  */
 export function isBlock(node) {
-    if (!(node instanceof Element)) {
+    if (node.nodeType !== Node.ELEMENT_NODE) {
         return false;
     }
     const tagName = node.nodeName.toUpperCase();


### PR DESCRIPTION
When in an iframe, the node passed to isBlock can be in a different window than `Element` so `node instanceof Element` will always be false.
This prevents an error triggered by this issue.