### PR TITLE
[IMP] keep cursor in an unremovable inline element after it was emptied

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -12,6 +12,7 @@ import {} from './commands/align.js';
 import { sanitize } from './utils/sanitize.js';
 import { nodeToObject, objectToNode } from './utils/serialize.js';
 import {
+    childNodeIndex,
     closestBlock,
     commonParentGet,
     containsUnremovable,
@@ -897,6 +898,13 @@ export class OdooEditor extends EventTarget {
             // Restore the text we modified in order to preserve trailing space.
             joinWith.textContent = oldText;
             setCursor(joinWith, nodeSize(joinWith));
+        }
+        if (joinWith) {
+            const el = closestElement(joinWith);
+            const { zws } = fillEmpty(el);
+            if (zws) {
+                setCursor(zws, 0, zws, nodeSize(zws));
+            }
         }
     }
 

--- a/src/tests/editor.test.js
+++ b/src/tests/editor.test.js
@@ -807,6 +807,13 @@ describe('Editor', () => {
                     contentAfter: '<h1>[]<br></h1><p>def</p>',
                 });
             });
+            it('should empty an inline unremovable but remain in it', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab<b class="oe_unremovable">[cd]</b>ef</p>',
+                    stepFunction: deleteForward,
+                    contentAfter: '<p>ab<b class="oe_unremovable">[\u200B]</b>ef</p>',
+                });
+            });
         });
     });
 
@@ -1853,6 +1860,13 @@ describe('Editor', () => {
                         </tbody></table>
                         <p>kl</p>`,
                     ),
+                });
+            });
+            it('should empty an inline unremovable but remain in it', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>ab<b class="oe_unremovable">[cd]</b>ef</p>',
+                    stepFunction: deleteBackward,
+                    contentAfter: '<p>ab<b class="oe_unremovable">[\u200B]</b>ef</p>',
                 });
             });
         });

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1240,15 +1240,27 @@ export function insertText(sel, content) {
 
 /**
  * Add a BR in the given node if its closest ancestor block has nothing to make
- * it visible.
+ * it visible, and/or add a zero-width space in the given node if it's an empty
+ * inline unremovable so the cursor can stay in it.
  *
  * @param {HTMLElement} el
+ * @returns {Object} { br: the inserted <br> if any,
+ *                     zws: the inserted zero-width space if any }
  */
 export function fillEmpty(el) {
+    const fillers = {};
     const blockEl = closestBlock(el);
     if (isShrunkBlock(blockEl)) {
-        blockEl.appendChild(document.createElement('br'));
+        const br = document.createElement('br');
+        blockEl.appendChild(br);
+        fillers.br = br;
     }
+    if (!el.textContent.length && isUnremovable(el) && !isBlock(el)) {
+        const zws = document.createTextNode('\u200B');
+        el.appendChild(zws);
+        fillers.zws = zws;
+    }
+    return fillers;
 }
 /**
  * Removes the given node if invisible and all its invisible ancestors.


### PR DESCRIPTION
We achieve this by inserting and selecting a zero-width space when deleting the element.
This is so far limited to unremovable elements but we could potentially expand this logic to all inlines if we choose to have that behavior. In that case though we'd have to handle the systematic removal of these potentially parasitic zero-width spaces, and adapt a lot of tests.