### PR TITLE
[FIX] properly set the cursor after delete next to font awesome

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -863,8 +863,11 @@ export class OdooEditor extends EventTarget {
         fillEmpty(closestBlock(range.endContainer));
         // Ensure trailing space remains visible.
         const joinWith = range.endContainer;
+        const joinSibling = joinWith && joinWith.nextSibling;
         const oldText = joinWith.textContent;
-        if (joinWith && oldText.endsWith(' ')) {
+        const hasSpaceAfter = joinSibling && joinSibling.textContent.startsWith(' ');
+        const shouldPreserveSpace = (doJoin || hasSpaceAfter) && joinWith && oldText.endsWith(' ');
+        if (shouldPreserveSpace) {
             joinWith.textContent = oldText.replace(/ $/, '\u00A0');
             setCursor(joinWith, nodeSize(joinWith));
         }
@@ -892,8 +895,7 @@ export class OdooEditor extends EventTarget {
         }
         next = joinWith && joinWith.nextSibling;
         if (
-            joinWith &&
-            oldText.endsWith(' ') &&
+            shouldPreserveSpace &&
             !(next && next.nodeType === Node.TEXT_NODE && next.textContent.startsWith(' '))
         ) {
             // Restore the text we modified in order to preserve trailing space.


### PR DESCRIPTION
In some cryptic cases, inserting a font awesome in text made it so that when selecting the character just after it gave us a deep range that was the text after that font awesome, at offset 0. This is correct, however it had a side effect in `deleteRange` in that it failed to properly set the cursor on correcting trailing spaces. In fact there was no space to preserved but it preserved it nonetheless, and we ended up at the end of the text.

This commit fixes that issue by being a little bit more restrictive in the preservation of space: only do it when absolutely necessary (two adjacent spaces or a trailing space and a merging of blocks).