### PR TITLE
[FIX] always identify and unbold bold text, and bind to CTRL+B

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -15,6 +15,7 @@ import {
     getTraversedNodes,
     insertText,
     isBlock,
+    isBold,
     isContentTextNode,
     isVisible,
     isVisibleStr,
@@ -289,9 +290,14 @@ export const editorCommands = {
         getDeepRange(editor.editable, { splitText: true, select: true, correctTripleClick: true });
         const isAlreadyBold = getSelectedNodes(editor.editable)
             .filter(n => n.nodeType === Node.TEXT_NODE && n.nodeValue.trim().length)
-            .find(n => Number.parseInt(getComputedStyle(n.parentElement).fontWeight) > 500);
+            .find(n => isBold(n.parentElement));
         applyInlineStyle(editor, el => {
-            el.style.fontWeight = isAlreadyBold ? 'normal' : 'bolder';
+            if (isAlreadyBold) {
+                const block = closestBlock(el);
+                el.style.fontWeight = isBold(block) ? 'normal' : getComputedStyle(block).fontWeight;
+            } else {
+                el.style.fontWeight = 'bolder';
+            }
         });
     },
     italic: editor => editor.document.execCommand('italic'),

--- a/src/editor.js
+++ b/src/editor.js
@@ -12,7 +12,6 @@ import {} from './commands/align.js';
 import { sanitize } from './utils/sanitize.js';
 import { nodeToObject, objectToNode } from './utils/serialize.js';
 import {
-    childNodeIndex,
     closestBlock,
     commonParentGet,
     containsUnremovable,
@@ -41,6 +40,7 @@ import {
     isEmptyBlock,
     getUrlsInfosInString,
     URL_REGEX,
+    isBold,
 } from './utils/utils.js';
 import { editorCommands } from './commands.js';
 import { CommandBar } from './commandbar.js';
@@ -1319,13 +1319,12 @@ export class OdooEditor extends EventTarget {
             }
         }
         if (sel.rangeCount) {
-            const closestsStartContainer = closestElement(sel.getRangeAt(0).startContainer, '*');
-            const selectionStartStyle = getComputedStyle(closestsStartContainer);
+            const closestStartContainer = closestElement(sel.getRangeAt(0).startContainer, '*');
+            const selectionStartStyle = getComputedStyle(closestStartContainer);
 
             // queryCommandState('bold') does not take stylesheets into account
-            const isBold = Number.parseInt(selectionStartStyle.fontWeight) > 500;
             const button = this.toolbar.querySelector('#bold');
-            button.classList.toggle('active', isBold);
+            button.classList.toggle('active', isBold(closestStartContainer));
 
             const fontSizeValue = this.toolbar.querySelector('#fontSizeCurrentValue');
             if (fontSizeValue) {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -836,6 +836,22 @@ export function isBlock(node) {
     return blockTagNames.includes(tagName);
 }
 
+/**
+ * Return true if the given node appears bold. The node is considered to appear
+ * bold if its font weight is bigger than 500 (eg.: Heading 1), or if its font
+ * weight is bigger than that of its closest block.
+ *
+ * @param {Node} node
+ * @returns {boolean}
+ */
+export function isBold(node) {
+    const fontWeight = +getComputedStyle(closestElement(node)).fontWeight;
+    return (
+        fontWeight > 500 ||
+        fontWeight > +getComputedStyle(closestBlock(node)).fontWeight
+    );
+}
+
 export function isUnbreakable(node) {
     if (!node || node.nodeType === Node.TEXT_NODE || !node.isContentEditable) {
         return false;


### PR DESCRIPTION
To avoid confusion with the upcoming `isBold` command, this also renames the functions that determine if a keyboard event corresponds to a certain shortcut, using all caps snake case.

The current method to identify bold text failed when the "bolder" font-weight was smaller than 500, which happens if the normal
font-weight is set to less than 400. This is the case with Bootstrap's "lead" class for instance.
Checking if it's bigger than 500 is useful for marking headings as being bold. However we need to also check if the element's font-weight is bigger than its parent block - in which case it should be considered bold.
Using `font-weight: normal` to unbold again fails if the inherited font-weight is smaller than 400 (eg: text in a ".lead" element inherits a font-weight of 300 but `font-weight: normal` is the same as `font-weight: 400` so setting `font-weight: normal` would make the text still end up bolder than the ".lead" element). In these cases we need to use the font-weight of said block.
It's an imperfect heuristic but it gets the job done in the vast majority of cases.