### PR TITLE
[FIX] prevent editing the toolbar with the toolbar

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -1705,10 +1705,13 @@ export class OdooEditor extends EventTarget {
     _bindToolbar() {
         for (const buttonEl of this.toolbar.querySelectorAll('[data-call]')) {
             buttonEl.addEventListener('mousedown', ev => {
-                this.execCommand(buttonEl.dataset.call, buttonEl.dataset.arg1);
+                const sel = this.document.getSelection()
+                if (sel.anchorNode && ancestors(sel.anchorNode).includes(this.editable)) {
+                    this.execCommand(buttonEl.dataset.call, buttonEl.dataset.arg1);
 
-                ev.preventDefault();
-                this._updateToolbar();
+                    ev.preventDefault();
+                    this._updateToolbar();
+                }
             });
         }
     }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -253,6 +253,7 @@ export function closestElement(node, selector) {
  * Returns a list of all the ancestors nodes of the provided node.
  *
  * @param {Node} node
+ * @param {Node} [editable] include to prevent bubbling up further than the editable.
  * @returns {HTMLElement[]}
  */
 export function ancestors(node, editable) {


### PR DESCRIPTION
Clicking in the (non-floating) toolbar, then on one of its buttons would edit the toolbar itself (eg., clicking on a list button would insert a list in the toolbar).
This adds a check on toolbar events so they can only affect what is in the editable area.