### PR TITLE
[FIX] properly create multi-paragraph list with whitespace

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -403,10 +403,14 @@ export const editorCommands = {
         const blocks = new Set();
 
         for (const node of getTraversedNodes(editor.editable)) {
-            const block = closestBlock(node);
-            if (!['OL', 'UL'].includes(block.tagName)) {
-                const ublock = block.closest('ol, ul');
-                ublock && getListMode(ublock) == mode ? li.add(block) : blocks.add(block);
+            if (node.nodeType === Node.TEXT_NODE && !isVisibleStr(node)) {
+                node.remove();
+            } else {
+                const block = closestBlock(node);
+                if (!['OL', 'UL'].includes(block.tagName)) {
+                    const ublock = block.closest('ol, ul');
+                    ublock && getListMode(ublock) == mode ? li.add(block) : blocks.add(block);
+                }
             }
         }
 


### PR DESCRIPTION
This addresses a bug that occurs when selecting over two paragraphs that are separated by some whitespace. It would create multiple indented lists.

Task: 2567795