### PR TITLE
[FIX] properly stop 'Tab' keydown event from propagating

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -1513,6 +1513,7 @@ export class OdooEditor extends EventTarget {
                 this.execCommand('insertText', '\u00A0 \u00A0\u00A0');
             }
             ev.preventDefault();
+            ev.stopPropagation();
         } else if (IS_KEYBOARD_EVENT_UNDO(ev)) {
             // Ctrl-Z
             ev.preventDefault();


### PR DESCRIPTION
This addresses a bug that occurred is Odoo when outdenting a list: besides outdenting, the 'Tab' keydown also did its default behavior so the cursor ended up in a different field.

Task: 2555704