### PR TITLE
[FIX] prevent shrunk blocks on split during insert html

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -16,6 +16,7 @@ import {
     isBlock,
     isBold,
     isContentTextNode,
+    isShrunkBlock,
     isVisible,
     isVisibleStr,
     leftDeepFirstPath,
@@ -87,6 +88,9 @@ function insert(editor, data, isText = true) {
             insertBefore = false;
         } else {
             startNode.after(nodeToInsert);
+        }
+        if (isShrunkBlock(startNode)) {
+            startNode.remove();
         }
         startNode = nodeToInsert;
     }


### PR DESCRIPTION
When inserting HTML, we sometimes need to split blocks to prevent weird nesting of blocks. However, that process has the potential of generating shrunk blocks (blocks without a height), such as `<p></p>`. This prevents it from happening.