### PR TITLE
[FIX] only send observerApply event when needed

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -441,7 +441,9 @@ export class OdooEditor extends EventTarget {
                 }
             }
         }
-        this.dispatchEvent(new Event('observerApply'));
+        if (records.length) {
+            this.dispatchEvent(new Event('observerApply'));
+        }
     }
     filterMutationRecords(records) {
         // Save the first attribute in a cache to compare only the first


### PR DESCRIPTION
REASON FOR THE FIX
To correctly display the overlay over a rotated element, we need to
reset the transform of the element, to be able to apply it on the
overlay.

Changing the style of the element in the SnippetEditor cover method
would trigger a DOM mutation, which will result in setting the
odooEditor observer unactive.

The issue was that flushing the observer (when setting it unactive)
would always send an event observerApply, even if no record was
processed.

It was an issue as the SnippetsMenu was triggering a content_changed
event at the reception of this event, which would rerender the
SnippetEditor overlay cover (and create an infinite loop of events).

SOLUTION
To avoid that, the observerApply event is sent only if records were
processed.

task-2554608