### PR TITLE
master-fix-selection-contenteditable-false-nby

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1849,3 +1849,6 @@ export function getRangePosition(el, document, options = {}) {
 
     return offset;
 }
+export function getClosestNotEditable(node, root) {
+    return node && ancestors(node, root).includes(root) && node.closest('[contenteditable=false]');
+}


### PR DESCRIPTION
Before, the code was updating the selection while the selection was changing. When changing selection
with the mouse, it created collapsed range in some case where it should not. We now correct the selection
on `mouseup` and `keyup` to avoid conflicting with the browser manipulating the selection on `mousemove`.

Also, the previous correction generated systematically a collapsed range whereas now it correct only the `range.startContainer` or `range.endContainer` individually.