### PR TITLE
[FIX] do not merge similar option elements when sanitizing

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -792,6 +792,7 @@ const blockTagNames = [
     'UL',
     // The following elements are not in the W3C list, for some reason.
     'SELECT',
+    'OPTION',
     'TR',
     'TD',
     'TBODY',


### PR DESCRIPTION
The sanitizer merges similar elements together but <option> elements should never be merged because they each represent a separate option, no matter if several consecutive options are the same. Options are blocks by default so failing to recognize that was the cause of the issue.