### PR TITLE
[FIX] highest not editable for selection fix 

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1850,6 +1850,3 @@ export function getRangePosition(el, document, options = {}) {
 
     return offset;
 }
-export function getClosestNotEditable(node, root) {
-    return node && ancestors(node, root).includes(root) && node.closest('[contenteditable=false]');
-}


### PR DESCRIPTION
When fixing the selection, the code was taking the closest not editable.
This is wrong as it should fix only the highest not editable from the provided node.

Before this fix in Odoo, getting the closest contenteditable=false gave the
Odoo website wrapper and therefore, was constantly wrongly reseting the
position on a website page at each mouseup.