### PR TITLE
[FIX] prevent splitting the wrong parent on paste

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -70,7 +70,7 @@ function insert(editor, data, isText = true) {
         if (isBlock(nodeToInsert) && !isBlock(startNode)) {
             // Split blocks at the edges if inserting new blocks (preventing
             // <p><p>text</p></p> scenarios).
-            while (startNode.parentElement !== editor.editable && !isBlock(startNode)) {
+            while (startNode.parentElement !== editor.editable && !isBlock(startNode.parentElement)) {
                 let offset = childNodeIndex(startNode);
                 if (!insertBefore) {
                     offset += 1;


### PR DESCRIPTION
When inserting blocks, we often need to split the node in which we're inserting. The code that makes that happen had an issue in its while statement that checked the wrong node, resulting in overreaching splits. This fixes that while statement.